### PR TITLE
On a desktop, always keep 4 items in a row.

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -17,15 +17,15 @@
   
   .resim1{
     display:flex;
-    /* flex: 1 0 21%; Anna*/
     flex-wrap: wrap;
-    justify-content: space-around;
+    justify-content: flex-start;
     gap: 10px;
     float:initial;
-    
+    padding: 10px;
   }
   
   .pc {
+    flex: 1 0 21%;
     min-width:300px;
     max-width:400px;
     border: 1px solid lightgray;


### PR DESCRIPTION
Flex is the shorthand for flex-grow, flex-shrink and flex-basis. The second and third parameters (flex-shrink and flex-basis) are optional.

If all items have **flex-grow** set to 1, every child will set to an equal size inside the container.

**Flex-shrink** specifies the “flex shrink factor” which determines how much the flex item will shrink relative to the rest of the flex items in the flex container when there isn’t enough space on the row.


The **flex-basis** property is a sub-property of the [Flexible Box Layout module](https://css-tricks.com/snippets/css/a-guide-to-flexbox/). It specifies the initial size of the flex item, before any available space is distributed according to the flex factors.

With flex-grow: 1 defined in the flex shorthand, there's no need for flex-basis to be 25%, which would actually result in three items per row due to the margins.

Since flex-grow will consume free space on the row, flex-basis only needs to be large enough to enforce a wrap. In this case, with flex-basis: 21%, there's plenty of space for the margins, but never enough space for a fifth item.